### PR TITLE
Edit the implementation detail for `touch-action`

### DIFF
--- a/policies/vertical_scroll.md
+++ b/policies/vertical_scroll.md
@@ -35,8 +35,7 @@ There are several techniques that can be used by an `<iframe>` to block user's a
 The propsoed solutoin is that disabled frames (i.e., those with `vertical-scroll 'none'`) will not be able to use
 either of the mentioned techniques. This is attained by:
   * Ensuring all scroll related input events are non-cancelable.
-  * All elements and nodes inside such frames do have either `pan-y` or at `pinch-zoom` in their `touch-action`
-  CSS property (if not, enforce `pan-y`)
+  * All elements and nodes inside such frames do have `pan-y` in their`touch-action` CSS property (if not, enforce `pan-y`).
   * Scripted and programmtic scorlling is handled within the scrop of a frame, i.e., calls to `element.scrollIntoView()`
   do not propagate outside of a disabled frame.
  


### PR DESCRIPTION
The original idea behind `pinch-zoom` was that even without `pan-y` the user should be still able to zoom out and then scroll the page by touch scrolling outside `<iframe>` bounds. However, this seems to still be an issue if the <iframe> is covering most of the window space event at small page scale factors.  So we should only enforce `pan-y` when it does not exit.