### PR TITLE
Add definitions to other page lifecyle feature policies

### DIFF
--- a/features.md
+++ b/features.md
@@ -22,6 +22,8 @@ specification.
 | `camera` | [Media Capture][media-capture] | Chrome 64 |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `fullscreen` | [Fullscreen API][fullscreen] | [Chrome 62](https://www.chromestatus.com/feature/5094837900541952) |
+| `execution-while-not-rendered` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
+| `execution-while-out-of-viewport` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `gyroscope` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `magnetometer` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `microphone` |[Media Capture][media-capture] | Chrome 64 |
@@ -86,6 +88,7 @@ names will be added to this list as they are actually defined.
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features
 [media-capture]: https://w3c.github.io/mediacapture-main/#feature-policy-integration
+[page-lifecycle]: https://wicg.github.io/page-lifecycle/spec.html#feature-policies
 [payment-request]: https://www.w3.org/TR/payment-request/#feature-policy
 [pip]: https://wicg.github.io/picture-in-picture/#feature-policy
 [wake-lock]: https://www.w3.org/TR/wake-lock/#dfn-wake-lock-feature


### PR DESCRIPTION
Feature policies to control freezing of a frame were added to the page-lifecycle specification. Add references here.