### PR TITLE
Expose new algorithms to create a Feature Policy before document is c…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -958,7 +958,7 @@ partial interface HTMLIFrameElement {
     <a>Feature Policy</a></p>
     <ol>
       <li>Let <var>policy</var> be the result of running <a>Create a Feature Policy for a browsing
-      context from response</a> given <var>document</var>'s <a>browsing context</a>, and <var>document</var>'s
+      context from response</a> given <var>document</var>'s <a>browsing context</a>, <var>document</var>'s
       <a>origin</a>, and <var>response</var>.</li>
       <li>
         Set <var>document</var>’s <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-feature-policy">feature policy</a> to <var>policy</var>.
@@ -967,15 +967,15 @@ partial interface HTMLIFrameElement {
   </section>
   <section>
     <h3 id="algo-define-inherited-policy"><dfn id="define-inherited-policy">Define an inherited policy for
-    <var>feature</var>, and <a>origin</a> in <a>browsing context</a></dfn></h3>
+    <var>feature</var> in <a>browsing context</a></dfn></h3>
     <p>Given a feature (<var>feature</var>), an <a>origin</a> (<var>origin</var>), and
-    a <a>browsing context</a> (<var>context</var>), this algorithm returns the
+    a <a>browsing context</a> (<var>browsingContext</var>), this algorithm returns the
     <a>inherited policy</a> for that feature.</p>
     <ol>
-      <li>If <var>context</var> is the [=nested browsing context=] of a
+      <li>If <var>browsingContext</var> is the [=nested browsing context=] of a
         [=browsing context container=] <var>element</var>, return the result of
         executing <a>Define an inherited policy for feature in container at
-        origin</a> for <var>feature</var> in <var>context</var>'s <a>browsing
+        origin</a> for <var>feature</var> in <var>browsingContext</var>'s <a>browsing
         context container</a> at <var>origin</var>.</li>
       <li>Otherwise, return "<code>Enabled</code>".</li>
     </ol>

--- a/index.bs
+++ b/index.bs
@@ -889,7 +889,7 @@ partial interface HTMLIFrameElement {
   <section>
     <h3 id="algo-create-for-browsingcontext"><dfn export id="create-for-browsingcontext">Create a
     Feature Policy for a browsing <var>context</var></dfn></h3>
-    <p>Given a <a>browsing context</a> (<var>browsingContext</var>), and <a>origin</a>
+    <p>Given a <a>browsing context</a> (<var>browsingContext</var>), and an <a>origin</a>
     (<var>origin</var>) this algorithm returns a new <a>Feature Policy</a>.</p>
     <ol>
       <li>Let <var>inherited policy</var> be a new ordered map.</li>

--- a/index.bs
+++ b/index.bs
@@ -887,19 +887,18 @@ partial interface HTMLIFrameElement {
     </ol>
   </section>
   <section>
-    <h3 id="algo-initialize-for-document"><dfn export
-    id="initialize-for-document">Initialize <var>document</var>'s Feature
-    Policy</var></dfn></h3>
-    <p>Given a {{Document}} object (<var>document</var>), this algorithm
-    initialises <var>document</var>'s <a>Feature Policy</a></p>
+    <h3 id="algo-create-for-browsingcontext"><dfn export id="create-for-browsingcontext">Create a
+    Feature Policy for a browsing <var>context</var></dfn></h3>
+    <p>Given a <a>browsing context</a> (<var>browsingContext</var>), and <a>origin</a>
+    (<var>origin</var>) this algorithm returns a new <a>Feature Policy</a>.</p>
     <ol>
       <li>Let <var>inherited policy</var> be a new ordered map.</li>
       <li>Let <var>declared policy</var> be a new ordered map.</li>
       <li>For each <var>feature</var> supported,
         <ol>
-          <li>Let <var>isInherited</var> be the result of running <a>Define an
-          inherited policy for feature in document</a> on <var>feature</var> and
-          <var>document</var>.
+          <li>Let <var>isInherited</var> be the result of running <a
+          href="#define-inherited-policy">Define an inherited policy for feature in browsing
+          context</a> on <var>feature</var>, <var>origin</var> and <var>browsingContext</var>.
           </li>
           <li>Set <var>inherited policy</var>[<var>feature</var>] to
             <var>isInherited</var>.</li>
@@ -909,9 +908,45 @@ partial interface HTMLIFrameElement {
       policy <var>inherited policy</var> and declared policy <var>declared
       policy</var>.
       </li>
+      <li>Return <var>policy</var>.</li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="algo-initialize-for-document"><dfn export
+    id="initialize-for-document">Initialize <var>document</var>'s Feature
+    Policy</dfn></h3>
+    <p>Given a {{Document}} object (<var>document</var>), this algorithm
+    initialises <var>document</var>'s <a>Feature Policy</a></p>
+    <ol>
+      <li>Let <var>policy</var> be the result of running <a>Create a Feature Policy for a browsing
+      context</a> given <var>document</var>'s <a>browsing context</a>, and <var>document</var>'s
+      <a>origin</a>.</li>
       <li>
         Set <var>document</var>’s <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-feature-policy">feature policy</a> to <var>policy</var>.
       </li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="algo-create-from-response"><dfn export
+    id="create-from-response">Create a Feature
+    Policy for a browsing <var>context</var> from <var>response</var></dfn></h3>
+    <p>Given a <a>browsing context</a> (<var>browsingContext</var>), <a>origin</a>
+    (<var>origin</var>), and a [=response=] (<var>response</var>), this algorithm returns a new
+    <a>Feature Policy</a></p>
+    <ol>
+      <li>Let <var>policy</var> be the result of running <a>Create a Feature Policy for a browsing
+      context</a> given <var>browsingContext</var>, and <var>origin</var>.</li>
+      <li>Let <var>d</var> be the result of running <a
+      href="#process-response-policy">Process response policy</a> on
+      <var>response</var> and <var>origin</var>.</li>
+      <li>For each <var>feature</var> → <var>allowlist</var> of <var>d</var>:
+        <ol>
+          <li>If <var>policy</var>'s <a>inherited policy</a>[<var>feature</var>] is true, then
+          set <var>policy</var>'s <a>declared policy</a>[<var>feature</var>] to
+          <var>allowlist</var>.</li>
+        </ol>
+      </li>
+      <li>Return <var>policy</var>.</li>
     </ol>
   </section>
   <section>
@@ -922,45 +957,26 @@ partial interface HTMLIFrameElement {
     (<var>document</var>), this algorithm populates <var>document</var>'s
     <a>Feature Policy</a></p>
     <ol>
-      <li><a>Initialize <var>document</var>'s
-      Feature Policy</a></li>
-      <li>Let <var>inherited policy</var> be <var>document</var>'s Feature
-      Policy's <a>inherited policy</a>.</li>
-      <li>Let <var>declared policy</var> be a new ordered map.</li>
-      <li>Let <var>d</var> be the result of running <a
-      href="#process-response-policy">Process response policy</a> on
-      <var>response</var> and <var>document</var>'s origin.</li>
-      <li>For each <var>feature</var> → <var>allowlist</var> of <var>d</var>:
-        <ol>
-          <li>If <var>inherited policy</var>[<var>feature</var>] is true, then
-          set <var>declared policy</var>[<var>feature</var>] to
-          <var>allowlist</var>.</li>
-        </ol>
-      </li>
-      <li>Let <var>policy</var> be a new <a>feature policy</a>, with inherited
-      policy <var>inherited policy</var> and declared policy <var>declared
-      policy</var>.
-      </li>
+      <li>Let <var>policy</var> be the result of running <a>Create a Feature Policy for a browsing
+      context from response</a> given <var>document</var>'s <a>browsing context</a>, and <var>document</var>'s
+      <a>origin</a>, and <var>response</var>.</li>
       <li>
         Set <var>document</var>’s <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-feature-policy">feature policy</a> to <var>policy</var>.
       </li>
     </ol>
   </section>
   <section>
-    <h3 id="algo-define-inherited-policy"><dfn>Define an inherited policy for
-    <var>feature</var> in <var>document</var></dfn></h3>
-    <p>Given a feature (<var>feature</var>) and a <a>Document</a>
-    (<var>document</var>), this algorithm returns the <a>inherited policy</a>
-    for that feature.</p>
+    <h3 id="algo-define-inherited-policy"><dfn id="define-inherited-policy">Define an inherited policy for
+    <var>feature</var>, and <a>origin</a> in <a>browsing context</a></dfn></h3>
+    <p>Given a feature (<var>feature</var>), an <a>origin</a> (<var>origin</var>), and
+    a <a>browsing context</a> (<var>context</var>), this algorithm returns the
+    <a>inherited policy</a> for that feature.</p>
     <ol>
-      <li>Let <var>context</var> be <var>document</var>'s <a>browsing
-      context</a>.</li>
       <li>If <var>context</var> is the [=nested browsing context=] of a
         [=browsing context container=] <var>element</var>, return the result of
         executing <a>Define an inherited policy for feature in container at
         origin</a> for <var>feature</var> in <var>context</var>'s <a>browsing
-        context container</a> at <var>document</var>'s
-        <a>origin</a>.</li>
+        context container</a> at <var>origin</var>.</li>
       <li>Otherwise, return "<code>Enabled</code>".</li>
     </ol>
   </section>


### PR DESCRIPTION
…reated.

Adjust algorithms so that the HTML spec will be able to create a feature
policy before the document is created. Instead of creating the document
first and then applying it afterwards. The document based algorithms
will remain until the HTML spec is changed.