### PR TITLE
Fix broken link to Page Lifecycle's feature-policies

### DIFF
--- a/features.md
+++ b/features.md
@@ -89,7 +89,7 @@ names will be added to this list as they are actually defined.
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features
 [media-capture]: https://w3c.github.io/mediacapture-main/#feature-policy-integration
-[page-lifecycle]: https://wicg.github.io/page-lifecycle/spec.html#feature-policies
+[page-lifecycle]: https://wicg.github.io/page-lifecycle/#feature-policies
 [payment-request]: https://www.w3.org/TR/payment-request/#feature-policy
 [pip]: https://wicg.github.io/picture-in-picture/#feature-policy
 [wake-lock]: https://www.w3.org/TR/wake-lock/#dfn-wake-lock-feature


### PR DESCRIPTION
Replace https://wicg.github.io/page-lifecycle/spec.html#feature-policies with https://wicg.github.io/page-lifecycle/#feature-policies.