### PR TITLE
webauthn => publickey-credentials

### DIFF
--- a/features.md
+++ b/features.md
@@ -46,7 +46,7 @@ integrated into their respective specs.
 | `encrypted-media` | https://github.com/w3c/encrypted-media/pull/432 | Chrome 64 |
 | `geolocation` | https://github.com/w3c/permissions/pull/163 | Chrome 64 |
 | `speaker` | https://github.com/w3c/mediacapture-main/issues/434 | Chrome 64 |
-| `webauthn` | [Web Authentication API][webauthn] | |
+| `publickey-credentials` | [Web Authentication API][publickey-credentials] | |
 
 
 ## Experimental Features
@@ -93,9 +93,9 @@ names will be added to this list as they are actually defined.
 [page-lifecycle]: https://wicg.github.io/page-lifecycle/#feature-policies
 [payment-request]: https://www.w3.org/TR/payment-request/#feature-policy
 [pip]: https://wicg.github.io/picture-in-picture/#feature-policy
+[publickey-credentials]: https://w3c.github.io/webauthn/#sctn-feature-policy
 [wake-lock]: https://www.w3.org/TR/wake-lock/#dfn-wake-lock-feature
 [web-midi]: https://webaudio.github.io/web-midi-api/#feature-policy-integration
-[publickey-credentials]: https://w3c.github.io/webauthn/#sctn-feature-policy
 [webusb]: https://wicg.github.io/webusb/#feature-policy
 [xhr]: https://xhr.spec.whatwg.org/#feature-policy-integration
 [xr]: https://immersive-web.github.io/webxr/#feature-policy


### PR DESCRIPTION
Change `webauthn` to `publickey-credentials` per @equalsJeffH's request in https://github.com/w3c/webappsec-feature-policy/pull/336 (that PR didn't change the name of the feature, only the markdown link name).