### PR TITLE
Move `encrypted-media` to standardized features

### DIFF
--- a/features.md
+++ b/features.md
@@ -20,16 +20,17 @@ specification.
 | `ambient-light-sensor` | [Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `autoplay` | [HTML][html] | [Chrome 64](https://www.chromestatus.com/feature/5100524789563392) |
 | `battery` | [Battery Status API][battery-status] | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=1007264)" in Chrome |
-| `camera` | [Media Capture][media-capture] | Chrome 64 |
+| `camera` | [Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `display-capture` | [Media Capture: Screen Share][media-capture-screen-share] | |
 | `document-domain` | [HTML][html] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
+| `encrypted-media` | [Encrypted Media Extensions][encrypted-media] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `fullscreen` | [Fullscreen API][fullscreen] | [Chrome 62](https://www.chromestatus.com/feature/5094837900541952) |
 | `execution-while-not-rendered` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `execution-while-out-of-viewport` | [Page Lifecycle][page-lifecycle] | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `gyroscope` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
 | `magnetometer` |[Generic Sensor API][generic-sensor] | [Chrome 66](https://www.chromestatus.com/feature/5758486868656128) |
-| `microphone` |[Media Capture][media-capture] | Chrome 64 |
-| `midi` | [Web MIDI][web-midi] | Chrome 64 |
+| `microphone` |[Media Capture][media-capture] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
+| `midi` | [Web MIDI][web-midi] | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 | `payment` | [Payment Request API][payment-request] | Chrome 60 |
 | `picture-in-picture` | [Picture-in-Picture][pip] | Shipped in Chrome |
 | `publickey-credentials` | [Web Authentication API][publickey-credentials] | Status "[Open](https://bugs.chromium.org/p/chromium/issues/detail?id=993007)" in Chrome |
@@ -46,9 +47,8 @@ integrated into their respective specs.
 | Feature name | Spec/PR link(s) | Browser Support |
 | ------------ | --------------- | --------------- |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
-| `encrypted-media` | https://github.com/w3c/encrypted-media/pull/432 | Chrome 64 |
-| `geolocation` | https://github.com/w3c/permissions/pull/163 | Chrome 64 |
-| `speaker` | https://github.com/w3c/mediacapture-main/issues/434 | Chrome 64 |
+| `geolocation` | https://github.com/w3c/permissions/pull/163 | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
+| `speaker` | https://github.com/w3c/mediacapture-main/issues/434 | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
 
 
 ## Experimental Features
@@ -88,6 +88,7 @@ names will be added to this list as they are actually defined.
 <a name="fn5">[5]</a>: The earlier version of this feature ([`lazyload`](https://www.chromestatus.com/feature/5641405942726656)) is available behind a flag in Chrome<sup>[1](#fn1)</sup>.
 
 [battery-status]: https://w3c.github.io/battery/#feature-policy-integration
+[encrypted-media]: https://w3c.github.io/encrypted-media/#feature-policy-integration
 [fullscreen]: https://fullscreen.spec.whatwg.org/#feature-policy-integration
 [generic-sensor]: https://www.w3.org/TR/generic-sensor/#feature-policy
 [html]: https://html.spec.whatwg.org/multipage/infrastructure.html#policy-controlled-features


### PR DESCRIPTION
`encrypted-media` is now in the spec per https://github.com/w3c/encrypted-media/commit/5ba4b1b273ba59fc2899ee509dcf7b60a95ba00f. Also added a link to [the Chrome bug ](https://www.chromestatus.com/feature/5023919287304192) that covers implementation of the `camera`, `encrypted-media`, `geolocation`, `microphone`, `midi`, and `speaker` features.