### PR TITLE
Remove obsolete speaker policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A web platform API which gives a website the ability to allow and deny the use of browser features in its own frame, and in iframes that it embeds. Examples of [features](https://github.com/w3c/webappsec-feature-policy/blob/master/features.md) that could be controlled by feature policy include:
 
-- getUserMedia (Camera, Speakers and Microphone)
+- getUserMedia (Camera and Microphone)
 - Fullscreen
 - Geolocation
 - MIDI

--- a/features.md
+++ b/features.md
@@ -49,8 +49,6 @@ integrated into their respective specs.
 | ------------ | --------------- | --------------- |
 | Client Hints<sup>[3](#fn3)</sup> | https://github.com/w3c/webappsec-feature-policy/issues/129 | |
 | `geolocation` | https://github.com/w3c/permissions/pull/163 | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
-| `speaker` | https://github.com/w3c/mediacapture-main/issues/434 | [Chrome 64](https://www.chromestatus.com/feature/5023919287304192) |
-
 
 ## Experimental Features
 


### PR DESCRIPTION
The speaker policy was listed as proposed, but decided not to be pursued in https://github.com/w3c/mediacapture-output/issues/63#issuecomment-539068488. The partial implementation in Chrome was removed in crbug.com/985892.