### PR TITLE
Remove "requires acknowledgment" flag from document policy

### DIFF
--- a/document-policy-explainer.md
+++ b/document-policy-explainer.md
@@ -381,11 +381,10 @@ frames.
 just the content that it embeds. It can be used in conjunction with the
 `Document-Policy` header, though.
 
-When you set a required document policy, most features will have to be
-acknowledged by the document being embedded, as otherwise it can be possible to
-affect the content on that page in unexpected ways. Any policies which require
-acknowledgment will be advertised with a `Sec-Required-Document-Policy` request
-header.
+When you set a required document policy, it will have to be acknowledged by the
+document being embedded, as otherwise it would be possible to affect the content
+on that page in unexpected ways. The required policy will be advertised with a
+`Sec-Required-Document-Policy` request header.
 
 If the content which is returned doesn't have a `Document-Policy` header which
 is at least as strict as the `Sec-Required-Document-Policy`, then it will not be
@@ -419,18 +418,11 @@ as a sandbox flag, can be controlled independently as well.
 
 ### More Details: Opting in to being embedded with a policy
 
-Some (most?) features require acknowledgment when they are part of a required
+Document policy features require acknowledgment when they are part of a required
 policy -- that is, a page cannot simply set the "`policy`" attribute on an
 iframe and impose the requirement on the page in the frame. The page being
 embedded must be serverd with its own `Document-Policy` header which
 acknowledges the requirement (specifying a policy which it at least as strict).
-Other features, such as the pre-existing sandbox flags, don't require
-acknowledgment. They are considered safe to impose on embedded content (mostly
-by virtue of the fact that the `sandbox` attribute has existsed for years with
-no such requirment.)
-
-As a starting point for discussion, all existing sandbox flags would not require
-acknowledgment, and all other document policies would.
 
 In documents generated from `data:` URLs, and in iframe srcdoc documents, where
 the parent document controls the content of the child explicitly, and there is
@@ -443,8 +435,8 @@ For an iframe, that required policy is the union<sup>[1](#fn1)</sup> of the
 parent's required document policy, the parent's `Require-Document-Policy`
 header, and the policy attribute of the containing iframe element.
 
-All features in the required policy which require acknowledgment will be
-advertised in a `Sec-Required-Document-Policy` request header.
+The required policy will be advertised in a `Sec-Required-Document-Policy`
+request header.
 
 Example:
 

--- a/document-policy.bs
+++ b/document-policy.bs
@@ -164,10 +164,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     for="configuration point">default value</dfn>, which is an element of its
     <a for="configuration point">range</a>.
 
-    A <a>configuration point</a> has a <dfn
-    for="configuration point">requires acknowlegement</dfn> flag, which is
-    either `yes` or `no`.
-
     A <a>configuration point</a> which has <a
     for="configuration point">type</a> `integer` or `float` also has a <a
     for="configuration point">parameter name</a>, which is a token, which must
@@ -179,11 +175,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
 
     <div class="informative">
     When introducing a new configuration point, the <a
-    for="configuration point">default value</a> and <a
-    for="configuration point">requires acknowlegment</a> flag should be chosen
-    carefully, with highest consideration given to web compatibility. When no
-    explicit policy has been declared for a document, the default value will be
-    in effect.
+    for="configuration point">default value</a> should be chosen carefully, with
+    highest consideration given to web compatibility. When no explicit policy
+    has been declared for a document, the default value will be in effect.
     </div>
   </section>
   <section>
@@ -583,8 +577,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     |declaredPolicy| is compatible with |requiredPolicy|, or false otherwise.
 
     1. For each |configuration point| → |value| in |requiredPolicy|:
-        1. If |configuration point|'s <a>requires acknowledgment</a> flag is
-            `no`, then continue.
         1. If |declaredPolicy|[|configuration point|] does not exist, then
             return false.
         1. If |value| is stricter than |declaredPolicy|[|configuration point|],
@@ -971,16 +963,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   # Privacy and Security # {#privacy-and-security}
 
   This specification standardizes a mechanism for an embedding page to set a
-  policy which will be enforced on an embedded page. When explicit
-  acknowledgment of a required policy is not required, similar to iframe
-  <{iframe/sandbox}>, this means that behaviors of existing features may be
-  changed in published web sites, by embedding them in another document with an
-  appropriate required policy.
+  policy which will be enforced on an embedded page. Explicit acknowledgment of
+  a required policy is required, however, unlike existing the existing iframe
+  <{iframe/sandbox}>, mechanism. This means that behaviors of existing features
+  cannot be changed in published web sites, without the cooperation of those
+  sites.
 
-  As such, the biggest privacy and security concerns are:
+  There are some privacy and security considerations to keep in mind with this
+  model:
 
   * Exposure of behavior in a cross-origin subframe to its embedder.
-  * Unanticipated behavior changes in subframes controlled by the embedder.
+  * Exposure of embedder state to the embedded document thorough policy.
+  * Unanticipated behavior change by blindly accepting a required policy.
 
   To a degree, these concerns are already present in the web platform, and this
   specification attempts to at least not make them needlessly worse.
@@ -990,7 +984,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   specification. This section attempts to provide some guidance as to what kinds
   of behaviors could cause such issues.
 
-  ## Exposure of cross-origin behavior {#exposure-of-cross-origin-behavior}
+  ## Exposure of cross-origin behavior ## {#exposure-of-cross-origin-behavior}
 
   Configuraton points should be designed such that a violation of the policy in
   a framed document is not observable by documents in other frames. For
@@ -1001,24 +995,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   then the embedder could disable that feature for the frame, and then listen
   for the resulting events to determine whether or not the user is logged in.
 
-  ## Unanticipated behavior changes ## {#unanticipated-behavior-changes}
-
-  Document policy grants a document the ability to control which features will
-  and will not be availble in a subframe at the time it is loaded. When a
-  feature represents an existing, long-standing behavior of the web platform,
-  this may mean that existing published content on the web was not written with
-  the expectation that a particular API could fail.
-
-  This is very similar to the existing iframe sandboxing mechanism, where
-  behavior can be changed without the explicit consent of the embedded page,
-  but it is not clear that is always safe.
-
-  When considering placing such a feature under policy control, standards
-  authors are strongly encouraged to require opt-in by the embedded document.
-  This means that existing content will not be allowed to be loaded in a context
-  where that behavior is changed, until it is configured to recognize and
-  accept the policy.
-
   ## Advertisement of required policy ## {#advertisement-of-required-policy}
 
   As a mitigation to the behavior change problem discussed above, requests for
@@ -1027,4 +1003,23 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   servers, and its contents may reveal details about the embedder page.
   Embedders should be aware of this when choosing to require a policy on their
   embedded content.
+
+  ## Blind acceptance of required policy ## {#blind-acceptance-of-policy}
+
+  Since adhering to the embedder-required policy is necessary in order to be
+  loaded, site owners may be tempted to configure web servers to simply echo the
+  `Sec-Required-Document-Policy` request header in the response's
+  `Document-Policy` header. While this will ensure that the document's policy is
+  always compatible with the request, it may open up the embedded document to
+  the risk that the embedder can alter control flow within it, by disabling or
+  changing the behavior of existing APIs. This is especially true as new
+  configuration points are added to the document policy model after the content
+  is written. It is difficult to future-proof a document against all possible
+  new behavior changes.
+
+  Sites which expect to be embedded in a context with a required document policy
+  can mitigate this by setting their policy to the actual strictest policy that
+  they know they can support, or by echoing the incoming policy for only the
+  configuration points which they are aware of, and understand the potential
+  scope of behavior changes.
 </section>


### PR DESCRIPTION
As this addresses the largest privacy and security risks, that section of the spec is updated as well. A new item is added noting the risks of blindly accepting a policy from the embedder.

Closes #375 