### PR TITLE
Add window-placement experimental feature

### DIFF
--- a/features.md
+++ b/features.md
@@ -71,6 +71,7 @@ experimentation by web developers.
 | `sync-script` | | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
 | `trust-token-redemption` | [Explainer](https://github.com/WICG/trust-token-api) | In [Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/2479231594867458049) in Chrome 84-87 |
 | `vertical-scroll` | [vertical\_scroll.md](policies/vertical_scroll.md) | Behind a flag in Chrome<sup>[1](#fn1)</sup> |
+| `window-placement` | [Explainer](https://github.com/webscreens/window-placement/blob/main/EXPLAINER.md) | In [Origin Trial](https://developer.chrome.com/origintrials/#/view_trial/-8087339030850568191) in Chrome 93-96 |
 
 
 ## Notes


### PR DESCRIPTION
Add an experimental feature entry for Chrome's Multi-Screen Window Placement API; see the [explainer excerpt](https://github.com/webscreens/window-placement/blob/main/EXPLAINER.md#add-permission-api-support-for-a-new-window-placement-entry):
> Window Placement is also a policy-controlled feature which is disabled by default for embedded cross-origin pages. If a cross-origin page wants an embedded page to have access to this API, then it needs to specify an allow attribute on the iframe, e.g. <iframe src="some_page.html" allow="window-placement"></iframe>