### PR TITLE
add none as an allowed default

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -399,7 +399,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
       navigables=].  It can be allowed {{Document}}s in [=/top-level
       traversables=] by delivering the {{Document}} with a suitable <a
       http-header> `Permissions-Policy`</a> header). It can be allowed
-      in in [=child navigables=] if it allowed in the parent
+      in [=child navigables=] if it is allowed in the parent
       {{Document}} by explicitly supplying a [=container policy=] on
       the [=navigable container=] that overrides this default and by
       delivering the {{Document}} with a suitable <a

--- a/index.bs
+++ b/index.bs
@@ -1056,7 +1056,9 @@ partial interface HTMLIFrameElement {
            policy</a>'s [=declared policy/declarations=][|feature|]
            <a>matches</a> |origin|, then return "<code>Enabled</code>".
         1. Otherwise return "<code>Disabled</code>".
-    1. Return "<code>Enabled</code>".
+    1. If |feature|'s <a>default allowlist</a> is <code>*</code> or
+       <code>self</code>, return "<code>Enabled</code>".
+    1. Return "<code>Disabled</code>".
 
     </div>
   </section>
@@ -1065,8 +1067,8 @@ partial interface HTMLIFrameElement {
 
     <div class="algorithm" data-algorithm="check-permissions-policy">
     To check a permissions policy, given [=permissions policy=] (|policy|), a
-    [=feature=] (|feature|), an [=origin=] (|origin|) and another [=origin=]
-    (|document origin|), this algorithm returns "<code>Disabled</code>" if
+    [=feature=] (|feature|), an [=origin=] (|origin|) and a {{Document}} object
+    (|document|), this algorithm returns "<code>Disabled</code>" if
     |feature| should be considered disabled, and "<code>Enabled</code>"
     otherwise.
     1. If |policy|'s <a for="permissions policy">inherited policy</a> for
@@ -1079,9 +1081,11 @@ partial interface HTMLIFrameElement {
         1. Otherwise return "<code>Disabled</code>".
     1. If |feature|'s <a>default allowlist</a> is <code>*</code>, return
       "<code>Enabled</code>".
+    1. Let |document origin| be |document|'s [=Document/origin=].
     1. If |feature|'s <a>default allowlist</a> is <code>'self'</code>, and
       |origin| is [=same origin=] with |document origin|, return
       "<code>Enabled</code>".
+    1. If |document| is a headerless document, return "<code>Enabled</code>".
     1. Return "<code>Disabled</code>".
 
     </div>
@@ -1111,7 +1115,7 @@ partial interface HTMLIFrameElement {
        permissions policy=].
     1. Let |result| be the result of calling <a abstract-op>Check permissions
        policy</a>, given |policy|,
-       |feature|, |origin|, and |document|'s [=Document/origin=].
+       |feature|, |origin|, and |document|.
     1. Let |report-only result| be the result of calling <a abstract-op>Check
        permissions policy</a>, given |report-only policy|, |feature|, |origin|,
        and |document|'s [=Document/origin=].

--- a/index.bs
+++ b/index.bs
@@ -393,6 +393,17 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
       by default in [=child navigables=] whose [=navigable/active
       document|document=] is cross-origin with its [=navigable/parent=]'s
       [=navigable/active document|document=].</dd>
+      <dt><dfn for="default allowlist" export><code>none</code></dfn></dt>
+      <dd>The feature is not allowed in {{Document}}s in [=/top-level
+      traversables=] by default, as well as those in all [=child
+      navigables=].  It can be allowed {{Document}}s in [=/top-level
+      traversables=] by delivering the {{Document}} with a suitable <a
+      http-header> `Permissions-Policy`</a> header). It can be allowed
+      in in [=child navigables=] if it allowed in the parent
+      {{Document}} by explicitly supplying a [=container policy=] on
+      the [=navigable container=] that overrides this default and by
+      delivering the {{Document}} with a suitable <a
+      http-header>`Permissions-Policy`</a> header.</dd>
     </dl>
   </section>
 </section>


### PR DESCRIPTION
Add `none` as a new possible default allowlist.

Surprisingly, I don't think this requires any updates to the algorithms as the updates would be to "Define an inherited policy for feature in container at origin" and "Is feature enabled in document for origin?" would both just be adding "If feature’s default allowlist is None, return "Disabled"." where we are going to return "Disabled" anyway.

Maybe we should add these conditions anyway, to make it explicit. Up to you.

Fixes #513

@clelland


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fergald/webappsec-permissions-policy/pull/515.html" title="Last updated on Jun 21, 2024, 6:22 AM UTC (59b2c00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/515/7a2bc78...fergald:59b2c00.html" title="Last updated on Jun 21, 2024, 6:22 AM UTC (59b2c00)">Diff</a>