### PR TITLE
Allow for User Agent discretion when checking permission policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1162,6 +1162,7 @@ partial interface HTMLIFrameElement {
     1. Let |report-only result| be the result of calling <a abstract-op>Check
        permissions policy</a>, given |report-only policy|, |feature|, |origin|,
        and |document|'s [=Document/origin=].
+    1. Let |result| be "<code>Disabled</code>" at the user agent's discretion.
     1. If |report| is True:
         1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":

--- a/index.bs
+++ b/index.bs
@@ -1162,7 +1162,12 @@ partial interface HTMLIFrameElement {
     1. Let |report-only result| be the result of calling <a abstract-op>Check
        permissions policy</a>, given |report-only policy|, |feature|, |origin|,
        and |document|'s [=Document/origin=].
-    1. Let |result| be "<code>Disabled</code>" at the user agent's discretion.
+    1. Optionally, set |result| to "<code>Disabled</code>" if the user agent deems it necessary.
+
+        Note: The user agent may wish to disallow particular contexts or scripts from using the 
+        API. See the <a 
+        href="https://github.com/explainers-by-googlers/selective-permissions-intervention">
+        Selective Permissions Intervention</a> as an example.
     1. If |report| is True:
         1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":

--- a/index.bs
+++ b/index.bs
@@ -1164,10 +1164,10 @@ partial interface HTMLIFrameElement {
        and |document|'s [=Document/origin=].
     1. Optionally, set |result| to "<code>Disabled</code>" if the user agent deems it necessary.
 
-        Note: The user agent may wish to disallow particular contexts or scripts from using the 
-        API. See the <a 
-        href="https://github.com/explainers-by-googlers/selective-permissions-intervention">
-        Selective Permissions Intervention</a> as an example.
+       Note: The user agent may wish to disallow particular contexts or scripts from using the 
+       API. See the <a 
+       href="https://github.com/explainers-by-googlers/selective-permissions-intervention">
+       Selective Permissions Intervention</a> as an example.
     1. If |report| is True:
         1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":

--- a/index.bs
+++ b/index.bs
@@ -1165,9 +1165,9 @@ partial interface HTMLIFrameElement {
     1. Optionally, set |result| to "<code>Disabled</code>" if the user agent deems it necessary.
 
        Note: The user agent may wish to disallow particular contexts or scripts from using the 
-       API. See the <a 
-       href="https://github.com/explainers-by-googlers/selective-permissions-intervention">
-       Selective Permissions Intervention</a> as an example.
+       API, such as to 
+       <a href="https://github.com/explainers-by-googlers/selective-permissions-intervention">
+       prevent ad scripts from accessing sensitive APIs like geolocation</a>.
     1. If |report| is True:
         1. Let |settings| be |document|'s <a>environment settings object</a>.
         1. If |result| is "<code>Disabled</code>":

--- a/index.bs
+++ b/index.bs
@@ -712,7 +712,8 @@ partial interface HTMLIFrameElement {
         object's <a>default origin</a>.
     2. Let |policy| be the <a>observable policy</a> for this
         {{PermissionsPolicy}} object's <a>associated node</a>.
-    3. If |feature| is allowed by |policy| for |origin|, return true.
+    3. If |feature| is allowed by |policy| (and the user agent) for |origin|,
+        return true.
     4. Otherwise, return false.
 
     <p>The {{features()}} method must run the following steps:</p>


### PR DESCRIPTION
The [Selective Permissions Intervention](https://github.com/explainers-by-googlers/selective-permissions-intervention/) allows the UA to Disable features for a given permissions policy check.

While small, this is a significant change in the sense that two calls in the same browsing context can have different responses. Notably, even if `allowedFeatures` says a feature is allowed, it may not be allowed for particular invocations. Any suggestions for additional prose/warnings are welcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jkarlin/webappsec-permissions-policy/pull/572.html" title="Last updated on Mar 3, 2026, 8:33 PM UTC (e3713ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/572/298d386...jkarlin:e3713ba.html" title="Last updated on Mar 3, 2026, 8:33 PM UTC (e3713ba)">Diff</a>