### PR TITLE
Rename PermissionsPolicy interface back to FeaturePolicy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -567,7 +567,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   <p>Documents and iframes both provide a {{FeaturePolicy}} object which can
   be used to inspect the permissions policies which apply to them.</p>
   <h4 id="document-policies">Document policies</h4>
-  <p>To retreive the currently effective policy, use
+  <p>To retrieve the currently effective policy, use
   <code>document.featurePolicy</code>. This returns a {{FeaturePolicy}}
   object, which can be used to:</p>
     * query the state (allowed or denied) in the current document for a given

--- a/index.bs
+++ b/index.bs
@@ -564,11 +564,11 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   whether a feature is enabled or not. (Some features may not have any
   observable failure mode, or may have unwanted side effects to feature
   detection.)</p>
-  <p>Documents and iframes both provide a {{PermissionsPolicy}} object which can
+  <p>Documents and iframes both provide a {{FeaturePolicy}} object which can
   be used to inspect the permissions policies which apply to them.</p>
   <h4 id="document-policies">Document policies</h4>
   <p>To retreive the currently effective policy, use
-  <code>document.permissionsPolicy</code>. This returns a {{PermissionsPolicy}}
+  <code>document.featurePolicy</code>. This returns a {{FeaturePolicy}}
   object, which can be used to:</p>
     * query the state (allowed or denied) in the current document for a given
         feature,
@@ -581,7 +581,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   <pre>
   &lt;!doctype html&gt;
   &lt;script&gt;
-   const policy = document.permissionsPolicy;
+   const policy = document.featurePolicy;
 
    // This will be true if this document can use WebUSB.
    const can_use_usb = policy.allowsFeature('usb');
@@ -625,7 +625,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   &lt;iframe id="frame" allow="fullscreen; xr-spatial-tracking"&gt;&lt;/iframe&gt;
   &lt;script&gt;
    const iframe_element = document.getElementById("frame");
-   const iframe_policy = iframe_element.permissionsPolicy;
+   const iframe_policy = iframe_element.featurePolicy;
 
    // True if the framed document will be allowed to use WebXR
    if (iframe_policy.allowsFeature('xr-spatial-tracking')) {
@@ -647,7 +647,7 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
   &lt;iframe id="frame" allow="fullscreen https://example.com" src="https://example.net/" &gt;&lt;/iframe&gt;
   &lt;script&gt;
    const iframe_element = document.getElementById("frame");
-   const iframe_policy = iframe_element.permissionsPolicy;
+   const iframe_policy = iframe_element.featurePolicy;
    // This will be false, as the URL listed in the src attribute is not allowed
    // by policy to use fullscreen.
    const is_fullscreen_allowed_in_frame = iframe_policy.allowsFeature('fullscreen');
@@ -656,17 +656,26 @@ spec: RFC8941; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8941#
    new_frame.allow = 'sync-xhr';
    // This will be true, as the iframe is allowed to use sync-xhr at whatever URL is
    // mentioned in its src attribute, even though that attribute is not yet set.
-   const is_sync_xhr_allowed = new_frame.permissionsPolicy.allowsFeature('sync-xhr');
+   const is_sync_xhr_allowed = new_frame.featurePolicy.allowsFeature('sync-xhr');
   &lt;/script&gt;
   </pre>
   </div>
   </section>
 
   <section>
-    <h3 id="the-policy-object">The permissionsPolicy object</h3>
+    <h3 id="the-policy-object">The featurePolicy object</h3>
+
+    Note: The JavaScript API uses the name `featurePolicy` (e.g.,
+    `document.featurePolicy`) rather than `permissionsPolicy` for web
+    compatibility. This specification was originally named "Feature Policy"
+    and was later renamed to "Permissions Policy" to better reflect its
+    purpose. However, the JavaScript API retains the original naming to
+    maintain compatibility with existing web content that relies on the
+    `featurePolicy` attribute.
+
     <pre class="idl">
 [Exposed=Window]
-interface PermissionsPolicy {
+interface FeaturePolicy {
   boolean allowsFeature(DOMString feature, optional DOMString origin);
   sequence&lt;DOMString&gt; features();
   sequence&lt;DOMString&gt; allowedFeatures();
@@ -674,44 +683,52 @@ interface PermissionsPolicy {
 };
 
 partial interface Document {
-    [SameObject] readonly attribute PermissionsPolicy permissionsPolicy;
+    [SameObject] readonly attribute FeaturePolicy featurePolicy;
 };
 
 partial interface HTMLIFrameElement {
-    [SameObject] readonly attribute PermissionsPolicy permissionsPolicy;
+    [SameObject] readonly attribute FeaturePolicy featurePolicy;
 };
     </pre>
-    <p>A {{PermissionsPolicy}} object has an <dfn>associated node</dfn>, which
+
+    Issue(401): The {{FeaturePolicy}} interface and the
+    {{Document/featurePolicy}} and {{HTMLIFrameElement/featurePolicy}}
+    attributes are [=at risk=] as a single-engine feature. There is
+    ongoing discussion about whether this functionality should be removed
+    from this specification, or potentially merged into the Permissions
+    API ({{Permissions/query()}}).
+
+    <p>A {{FeaturePolicy}} object has an <dfn>associated node</dfn>, which
     is a {{Node}}. The <a>associated node</a> is set when the
-    {{PermissionsPolicy}} object is created.</p>
-    <p>A {{PermissionsPolicy}} object has a <dfn>default origin</dfn>, which is
+    {{FeaturePolicy}} object is created.</p>
+    <p>A {{FeaturePolicy}} object has a <dfn>default origin</dfn>, which is
     an <a>origin</a>, whose value depends on the state of the
-    {{PermissionsPolicy}} object's <a>associated node</a>:</p>
-    * If the {{PermissionsPolicy}} object's <a>associated node</a> is a
+    {{FeaturePolicy}} object's <a>associated node</a>:</p>
+    * If the {{FeaturePolicy}} object's <a>associated node</a> is a
         {{Document}}, then its <a>default origin</a> is the {{Document}}'s
         <a>origin</a>.
-    * If the {{PermissionsPolicy}} object's <a>associated node</a> is an
+    * If the {{FeaturePolicy}} object's <a>associated node</a> is an
         {{Element}}, then its <a>default origin</a> is the {{Element}}'s
         <a>declared origin</a>.
 
     <p>Each {{Document}} has a <dfn for="Document">policy object</dfn>, which is
-    a {{PermissionsPolicy}} instance whose <a>associated node</a> is that
+    a {{FeaturePolicy}} instance whose <a>associated node</a> is that
     {{Document}}.</p>
-    <p>A {{Document}}'s {{Document/permissionsPolicy}} IDL attribute, on
+    <p>A {{Document}}'s {{Document/featurePolicy}} IDL attribute, on
     getting, must return the {{Document}}'s [=Document/policy object=].</p>
 
     <p>Each <{iframe}> element has a <dfn for="iframe">policy object</dfn>,
-    which is a {{PermissionsPolicy}} instance whose <a>associated node</a> is
+    which is a {{FeaturePolicy}} instance whose <a>associated node</a> is
     that element.</p>
-    <p>An <{iframe}>'s {{HTMLIFrameElement/permissionsPolicy}} IDL attribute, on
+    <p>An <{iframe}>'s {{HTMLIFrameElement/featurePolicy}} IDL attribute, on
     getting, must return the <{iframe}>'s [=iframe/policy object=].</p>
 
     <p>The {{allowsFeature(feature, origin)}} method must run the following
     steps:</p>
-    1. If |origin| is omitted, set |origin| to this {{PermissionsPolicy}}
+    1. If |origin| is omitted, set |origin| to this {{FeaturePolicy}}
         object's <a>default origin</a>.
     2. Let |policy| be the <a>observable policy</a> for this
-        {{PermissionsPolicy}} object's <a>associated node</a>.
+        {{FeaturePolicy}} object's <a>associated node</a>.
     3. If |feature| is allowed by |policy| for |origin|, return true.
     4. Otherwise, return false.
 
@@ -723,10 +740,10 @@ partial interface HTMLIFrameElement {
 
     <p>The {{allowedFeatures()}} method must run the following steps:</p>
     1. Set |result| to an empty ordered set.
-    2. Let |origin| be this {{PermissionsPolicy}} object's <a>default
+    2. Let |origin| be this {{FeaturePolicy}} object's <a>default
         origin</a>.
     3. Let |policy| be the <a>observable policy</a> for this
-        {{PermissionsPolicy}} object's <a>associated node</a>.
+        {{FeaturePolicy}} object's <a>associated node</a>.
     4. For each <a>supported feature</a> |feature|:
         1. If |feature| is allowed by |policy| for |origin|, append |feature| to
             |result|.
@@ -735,10 +752,10 @@ partial interface HTMLIFrameElement {
     <p>The {{getAllowlistForFeature(feature)}} method must run the following
     steps:</p>
     1. Set |result| to an empty list.
-    2. Let |origin| be this {{PermissionsPolicy}} object's <a>default
+    2. Let |origin| be this {{FeaturePolicy}} object's <a>default
        origin</a>.
     3. Let |policy| be the <a>observable policy</a> for this
-       {{PermissionsPolicy}} object's <a>associated node</a>.
+       {{FeaturePolicy}} object's <a>associated node</a>.
     4. If |feature| is not allowed in |policy| for |origin|, return |result|
     5. Let |allowlist| be |policy|'s [=/declared policy=][|feature|]'s
        [=declared policy/declarations=].


### PR DESCRIPTION
Chrome shows that ~37% of sites tested are using `document.featurePolicy`:
https://chromestatus.com/metrics/feature/timeline/popularity/2511

We should consider switching this back.

Related web platform tests:
https://github.com/web-platform-tests/wpt/pull/58463


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/pull/582.html" title="Last updated on Mar 13, 2026, 6:25 AM UTC (76590be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-permissions-policy/582/876a190...76590be.html" title="Last updated on Mar 13, 2026, 6:25 AM UTC (76590be)">Diff</a>