### PR TITLE
Add WebMCP link to features.md

### DIFF
--- a/features.md
+++ b/features.md
@@ -61,6 +61,7 @@ specification.
 | `serial` | [Web Serial API][web-serial] | [Chrome 89](https://chromestatus.com/feature/6577673212002304) |
 | `sync-xhr` | [XMLHttpRequest][xhr] | [Chrome 65](https://www.chromestatus.com/feature/5154875084111872) |
 | `storage-access` | [Storage Access][storage-access] | [Chrome 115](https://chromestatus.com/feature/5612590694662144) |
+| `tools` | [WebMCP][webmcp] | [Available as a Chrome Origin Trial](https://developers.chrome.com/origintrials/#/trials/active) |
 | `usb` | [WebUSB][webusb] | Chrome 60 |
 | `web-share` | [Web Share API][web-share] | Chrome 86 |
 | `window-management`<sup>[5](#fn5)</sup> | [Window Management API][window-management] | [Chrome 111](https://chromestatus.com/feature/5146352391028736) |
@@ -177,6 +178,7 @@ changed in [Chrome 111](https://chromestatus.com/feature/5146352391028736) to `w
 [publickey-credentials-get]: https://w3c.github.io/webauthn/#sctn-permissions-policy
 [storage-access]: https://privacycg.github.io/storage-access/#permissions-policy-integration
 [wake-lock]: https://w3c.github.io/screen-wake-lock/#policy-control
+[webmcp]: https://webmachinelearning.github.io/webmcp/#permissions-policy
 [web-midi]: https://webaudio.github.io/web-midi-api/#permissions-policy-integration
 [web-serial]: https://wicg.github.io/serial/#permissions-policy
 [web-share]: https://w3c.github.io/web-share/#permissions-policy


### PR DESCRIPTION
I strongly agree with everything that @marcoscaceres said in https://github.com/w3c/webappsec-permissions-policy/issues/581, however since no such process exists, this PR follows the implicit format that all the others did, by linking to the permission policy integration section of the spec I'm documenting here, and linking to the Chrome Origin Trial dashboard, unfortunately :////